### PR TITLE
Wifibundlebank

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Wifibundlebank
+# Wifibundlebank, This app will store data bundles upto 50GB,one can turn this app on when they are using free wifi at home and it will store data to be used when you are traveling or at work. Hence someone can hotspot you while you store his/her data to be  used later.


### PR DESCRIPTION
This app will be used to store data bundles when people are using free wifi at home or at work even when hotspoted. Hence one has to turn on this app whenever they want to use it when traveling or anywere one prefers to use it from. However it can on store up to 1TB of Browsing data an expires after a month.
